### PR TITLE
feat(cli): add render pipeline for up command

### DIFF
--- a/cli/go.sum
+++ b/cli/go.sum
@@ -7,4 +7,5 @@ github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wx
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/cli/internal/render/render.go
+++ b/cli/internal/render/render.go
@@ -1,0 +1,160 @@
+package render
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+var varPattern = regexp.MustCompile(`\$\{([A-Z0-9_]+)\}`)
+
+// ReplaceVariables substitutes ${VAR} placeholders in content using values.
+func ReplaceVariables(content string, values map[string]string) string {
+	return varPattern.ReplaceAllStringFunc(content, func(match string) string {
+		key := varPattern.FindStringSubmatch(match)[1]
+		if v, ok := values[key]; ok {
+			return v
+		}
+		return match
+	})
+}
+
+// ValidateYAML ensures the content is valid YAML (all documents).
+func ValidateYAML(content string) error {
+	dec := yaml.NewDecoder(strings.NewReader(content))
+	for {
+		var v interface{}
+		err := dec.Decode(&v)
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+	}
+}
+
+// RenderFiles reads template files, substitutes values, validates YAML, and writes to outDir.
+func RenderFiles(paths []string, values map[string]string, outDir string) error {
+	for _, p := range paths {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		rendered := ReplaceVariables(string(data), values)
+		if err := ValidateYAML(rendered); err != nil {
+			return fmt.Errorf("%s: %w", p, err)
+		}
+		outPath := filepath.Join(outDir, filepath.Base(p))
+		if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(outPath, []byte(rendered), 0o644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ProviderValues holds defaults from values.example.yaml.
+type ProviderValues struct {
+	ClusterName  string `yaml:"clusterName"`
+	Namespace    string `yaml:"namespace"`
+	Region       string `yaml:"region"`
+	K8sMinor     string `yaml:"k8sMinor"`
+	TalosVersion string `yaml:"talosVersion"`
+	ControlPlane struct {
+		Replicas     int    `yaml:"replicas"`
+		InstanceType string `yaml:"instanceType"`
+	} `yaml:"controlPlane"`
+	Workers struct {
+		Replicas     int    `yaml:"replicas"`
+		InstanceType string `yaml:"instanceType"`
+	} `yaml:"workers"`
+}
+
+// LoadProviderValues parses a provider values file.
+func LoadProviderValues(path string) (*ProviderValues, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var pv ProviderValues
+	if err := yaml.Unmarshal(data, &pv); err != nil {
+		return nil, err
+	}
+	return &pv, nil
+}
+
+// ValuesFromProvider builds substitution values using provider defaults.
+func ValuesFromProvider(provider string, pv *ProviderValues) map[string]string {
+	vals := map[string]string{
+		"CLUSTER_NAME":           pv.ClusterName,
+		"NAMESPACE":              pv.Namespace,
+		"REGION":                 pv.Region,
+		"K8S_MINOR":              pv.K8sMinor,
+		"TALOS_VERSION":          pv.TalosVersion,
+		"CP_COUNT":               strconv.Itoa(pv.ControlPlane.Replicas),
+		"WORKER_COUNT":           strconv.Itoa(pv.Workers.Replicas),
+		"PROVIDER_SPEC_CP":       pv.ControlPlane.InstanceType,
+		"PROVIDER_SPEC_WORKER":   pv.Workers.InstanceType,
+		"CONTROL_PLANE_ENDPOINT": "",
+	}
+	switch provider {
+	case "aws":
+		vals["INFRA_CLUSTER_KIND"] = "AWSCluster"
+		vals["INFRA_MACHINE_TEMPLATE_KIND"] = "AWSMachineTemplate"
+	case "azure":
+		vals["INFRA_CLUSTER_KIND"] = "AzureCluster"
+		vals["INFRA_MACHINE_TEMPLATE_KIND"] = "AzureMachineTemplate"
+	case "gcp":
+		vals["INFRA_CLUSTER_KIND"] = "GCPCluster"
+		vals["INFRA_MACHINE_TEMPLATE_KIND"] = "GCPMachineTemplate"
+	case "proxmox":
+		vals["INFRA_CLUSTER_KIND"] = "ProxmoxCluster"
+		vals["INFRA_MACHINE_TEMPLATE_KIND"] = "ProxmoxMachineTemplate"
+	}
+	return vals
+}
+
+// RenderRecipes writes Flux Kustomizations for recipe bundles.
+func RenderRecipes(recipes []string, outDir string) error {
+	for _, r := range recipes {
+		var b strings.Builder
+		b.WriteString("apiVersion: kustomize.toolkit.fluxcd.io/v1\n")
+		b.WriteString("kind: Kustomization\n")
+		b.WriteString("metadata:\n")
+		b.WriteString(fmt.Sprintf("  name: %s\n", r))
+		b.WriteString("  namespace: flux-system\n")
+		b.WriteString("spec:\n")
+		b.WriteString("  interval: 10m\n")
+		b.WriteString(fmt.Sprintf("  path: ./recipes/%s\n", r))
+		b.WriteString("  prune: true\n")
+		b.WriteString("  sourceRef:\n")
+		b.WriteString("    kind: GitRepository\n")
+		b.WriteString("    name: infraflux\n")
+		b.WriteString("    namespace: flux-system\n")
+		if r != "base" {
+			b.WriteString("  dependsOn:\n")
+			b.WriteString("    - name: base\n")
+		}
+		content := b.String()
+		if err := ValidateYAML(content); err != nil {
+			return fmt.Errorf("recipe %s: %w", r, err)
+		}
+		if err := os.MkdirAll(outDir, 0o755); err != nil {
+			return err
+		}
+		outPath := filepath.Join(outDir, fmt.Sprintf("%s.yaml", r))
+		if err := os.WriteFile(outPath, []byte(content), 0o644); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/clusters/aws/README.md
+++ b/clusters/aws/README.md
@@ -1,0 +1,17 @@
+# AWS Provider Overlay
+
+This directory contains AWS-specific defaults for the InfraFlux renderer.
+
+`values.example.yaml` provides baseline values consumed by `infraflux up`:
+
+- `clusterName`
+- `namespace`
+- `region`
+- `k8sMinor`
+- `talosVersion`
+- `controlPlane.replicas`
+- `controlPlane.instanceType`
+- `workers.replicas`
+- `workers.instanceType`
+
+These settings are merged with command line flags during rendering.

--- a/out/example-lab/addons/cilium/helmrelease.yaml
+++ b/out/example-lab/addons/cilium/helmrelease.yaml
@@ -1,0 +1,19 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cilium
+  namespace: kube-system
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: cilium
+      version: 1.15.x
+      sourceRef:
+        kind: HelmRepository
+        name: cilium
+        namespace: flux-system
+  values:
+    kubeProxyReplacement: true
+    k8sServiceHost:  # optionally set by overlay
+    k8sServicePort: 6443

--- a/out/example-lab/addons/gateway/envoy-gateway-helmrelease.yaml
+++ b/out/example-lab/addons/gateway/envoy-gateway-helmrelease.yaml
@@ -1,0 +1,16 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: envoy-gateway
+  namespace: envoy-gateway-system
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: gateway-helm
+      version: 1.0.x
+      sourceRef:
+        kind: HelmRepository
+        name: envoy-gateway
+        namespace: flux-system
+  values: {}

--- a/out/example-lab/cluster/base-cluster.yaml
+++ b/out/example-lab/cluster/base-cluster.yaml
@@ -1,0 +1,30 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+    name: example-lab
+    namespace: default
+spec:
+    clusterNetwork:
+        pods:
+            cidrBlocks: [ "10.244.0.0/16" ]
+        services:
+            cidrBlocks: [ "10.96.0.0/12" ]
+    controlPlaneRef:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: TalosControlPlane
+        name: example-lab-control-plane
+    infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: AWSCluster # e.g., AWSCluster, AzureCluster, GCPCluster, ProxmoxCluster
+        name: example-lab
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: TalosConfigTemplate
+metadata:
+    name: example-lab-worker-template
+    namespace: default
+spec:
+    template:
+        spec:
+            talosVersion: v1.7.5
+            generateType: "join"

--- a/out/example-lab/cluster/talos-control-plane.yaml
+++ b/out/example-lab/cluster/talos-control-plane.yaml
@@ -1,0 +1,16 @@
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: TalosControlPlane
+metadata:
+    name: example-lab-control-plane
+    namespace: default
+spec:
+    replicas: 3
+    version: v1.30.0
+    infrastructureTemplate:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: AWSMachineTemplate # e.g., AWSMachineTemplate, ProxmoxMachineTemplate
+        name: example-lab-cp
+    talosConfig:
+        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+        kind: TalosConfigTemplate
+        name: example-lab-cp-template

--- a/out/example-lab/cluster/talos-machine-template-controlplane.yaml
+++ b/out/example-lab/cluster/talos-machine-template-controlplane.yaml
@@ -1,0 +1,10 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AWSMachineTemplate
+metadata:
+    name: example-lab-cp
+    namespace: default
+spec:
+    template:
+        spec:
+            # Provider-specific fields go into overlays (instanceType, image, network, disks, etc.)
+            providerID: t3.medium

--- a/out/example-lab/cluster/talos-machine-template-worker.yaml
+++ b/out/example-lab/cluster/talos-machine-template-worker.yaml
@@ -1,0 +1,37 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AWSMachineTemplate
+metadata:
+    name: example-lab-md-0
+    namespace: default
+spec:
+    template:
+        spec:
+            providerID: t3.large
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+    name: example-lab-md-0
+    namespace: default
+spec:
+    clusterName: example-lab
+    replicas: 2
+    selector:
+        matchLabels:
+            cluster.x-k8s.io/deployment-name: example-lab-md-0
+    template:
+        metadata:
+            labels:
+                cluster.x-k8s.io/deployment-name: example-lab-md-0
+        spec:
+            bootstrap:
+                configRef:
+                    apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+                    kind: TalosConfigTemplate
+                    name: example-lab-worker-template
+            clusterName: example-lab
+            infrastructureRef:
+                apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+                kind: AWSMachineTemplate
+                name: example-lab-md-0
+            version: v1.30.0

--- a/out/example-lab/recipes/base.yaml
+++ b/out/example-lab/recipes/base.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: base
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./recipes/base
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: infraflux
+    namespace: flux-system


### PR DESCRIPTION
## Summary
- extend `infraflux up` to render cluster, addons, and recipe manifests
- add internal render engine for ${VAR} substitution and YAML validation
- document AWS provider defaults and add example output tree

## Testing
- `go build ./...`
- `go run . up --provider aws --name example-lab --region us-east-1`
- `find out/example-lab -maxdepth 3 -type f -print`


------
https://chatgpt.com/codex/tasks/task_e_6898b3394cb483238ca49355dc97d8db