### PR TITLE
feat(cli): expose node sizing variables

### DIFF
--- a/cli/cmd/up.go
+++ b/cli/cmd/up.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -53,6 +54,8 @@ var upCmd = &cobra.Command{
 			pv.Workers.Replicas = upOpts.Workers
 		}
 		values := render.ValuesFromProvider(upOpts.Provider, pv)
+		values["VCPU"] = strconv.Itoa(upOpts.CPUs)
+		values["MEMORY_GI"] = strconv.Itoa(upOpts.MemoryGi)
 
 		tmplPaths, err := filepath.Glob(filepath.Join(root, "clusters", "templates", "*.yaml"))
 		if err != nil {

--- a/clusters/proxmox/README.md
+++ b/clusters/proxmox/README.md
@@ -1,0 +1,19 @@
+# Proxmox provider overlay
+
+This directory contains Proxmox-specific defaults used by `infraflux up` when rendering a cluster plan.
+
+## values.example.yaml
+
+The `values.example.yaml` file defines baseline settings:
+
+- `clusterName`: name of the workload cluster.
+- `namespace`: namespace for Cluster API resources.
+- `region`: logical datacenter or region name.
+- `k8sMinor`: Kubernetes minor version to deploy.
+- `talosVersion`: Talos Linux release for nodes.
+- `controlPlane.replicas`: number of control plane machines.
+- `controlPlane.instanceType`: Proxmox template or hardware ID for control plane nodes.
+- `workers.replicas`: number of worker machines.
+- `workers.instanceType`: Proxmox template or hardware ID for worker nodes.
+
+All values may be overridden with CLI flags when executing `infraflux up`.


### PR DESCRIPTION
## Summary
- expose CPU and memory flags as template variables for `infraflux up`
- document default values for Proxmox provider overlay

## Testing
- `cd cli && go build ./...`
- `go run . up --provider proxmox --name example-lab`
- `mkdocs build --strict` (warnings: missing nav entries)

<details><summary>Rendered sample</summary>

```
out/example-lab
out/example-lab/addons
out/example-lab/addons/gateway
out/example-lab/addons/cilium
out/example-lab/cluster
out/example-lab/cluster/talos-machine-template-controlplane.yaml
out/example-lab/cluster/talos-machine-template-worker.yaml
out/example-lab/cluster/base-cluster.yaml
out/example-lab/cluster/talos-control-plane.yaml
out/example-lab/recipes
out/example-lab/recipes/base.yaml
```

</details>

------
https://chatgpt.com/codex/tasks/task_e_6898b760bc4c832392016abba5fb4eec