### PR TITLE
Add example prod cluster and Proxmox provider config

### DIFF
--- a/clusters/prod/README.md
+++ b/clusters/prod/README.md
@@ -1,0 +1,3 @@
+# Production cluster manifests
+
+Example Cluster API manifests for a Proxmox-based Talos cluster.

--- a/clusters/prod/prod-cluster.yaml
+++ b/clusters/prod/prod-cluster.yaml
@@ -1,0 +1,21 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: prod-cluster
+  namespace: default
+spec:
+  clusterNetwork:
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: TalosControlPlane
+    name: prod-cluster-control-plane
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+    kind: ProxmoxCluster
+    name: prod-cluster

--- a/terraform/00-proxmox-foundation/versions.tf
+++ b/terraform/00-proxmox-foundation/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers {
+    proxmox = {
+      source  = "Telmate/proxmox"
+      version = "3.0.1-rc5"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add placeholder production Cluster API manifest for Proxmox/Talos
- define base Terraform module with pinned Proxmox provider

## Testing
- `pre-commit run --files clusters/prod/README.md clusters/prod/prod-cluster.yaml terraform/00-proxmox-foundation/versions.tf`
- `terraform -chdir=terraform/00-proxmox-foundation init -input=false`
- `terraform -chdir=terraform/00-proxmox-foundation plan -input=false`


------
https://chatgpt.com/codex/tasks/task_e_689b465d355483239a00f1838e2fdecb