### PR TITLE
chore: scaffold terraform modules and secrets

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,16 @@
+name: Pre-commit
+on:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: --all-files

--- a/.kubeconform.yaml
+++ b/.kubeconform.yaml
@@ -1,0 +1,5 @@
+kubernetesVersion: "1.29.0"
+strict: true
+ignoreMissingSchemas: true
+ignoreFilenamePattern:
+  - secrets/

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,4 @@
+creation_rules:
+  - path_regex: secrets/.*\\.sops\\.yaml$
+    encrypted_regex: '^(data|stringData)$'
+    age: AGE_PUBLIC_KEY_PLACEHOLDER

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Infrastructure-as-code for Talos Linux + Cluster API on Proxmox, managed declara
   - `30-capmox/` – Proxmox provider setup (placeholder)
   - `40-clusters/` – workload cluster automation (placeholder)
   - `50-argo/` – Argo CD installation (placeholder)
-  - `mgmt-proxmox-talos/` – active module for Talos bootstrap + CAPI Operator helm release
+  - `mgmt-proxmox-talos/` – active module for Talos bootstrap + CAPI Operator helm release (includes `terraform.tfvars.example`)
 - `clusters/`
   - `mgmt/` – provider/operator configuration for the management cluster
   - `prod/` – workload cluster manifests (to be added)
@@ -25,7 +25,8 @@ Infrastructure-as-code for Talos Linux + Cluster API on Proxmox, managed declara
   - `values/` – Argo CD chart values
 - `secrets/`
   - `age/` – guidance for SOPS age keys
-- repo hygiene: `.pre-commit-config.yaml`, `.kubeconform.yaml`, `.yamllint`, `.markdownlint.json`, `.vscode/`
+  - `README.md` and `proxmox-credentials.sops.example.yaml`
+- repo hygiene: `.pre-commit-config.yaml`, `.kubeconform.yaml`, `.sops.yaml`, `.yamllint`, `.markdownlint.json`, `.vscode/`
 
 ## end-to-end plan
 

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -16,6 +16,8 @@ After Argo syncs:
 
 Notes:
 
+- Use `terraform/mgmt-proxmox-talos/terraform.tfvars.example` for variable guidance
+- Copy `secrets/proxmox-credentials.sops.example.yaml` and encrypt with SOPS before applying
 - Keep secrets encrypted with SOPS (platform/secrets)
 - Use kubeconform CI to validate manifests
 - Prefer Gateway API over Ingress where possible

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -1,0 +1,7 @@
+# Secrets
+
+Encrypted secrets live here. Use SOPS with age to encrypt any secret material.
+
+1. Generate an age key and create the `sops-age` Kubernetes Secret (see `secrets/age/README.age.md`).
+2. Copy `proxmox-credentials.sops.example.yaml` to `proxmox-credentials.sops.yaml` and replace placeholders.
+3. Encrypt with `sops --encrypt proxmox-credentials.sops.yaml` before committing.

--- a/secrets/proxmox-credentials.sops.example.yaml
+++ b/secrets/proxmox-credentials.sops.example.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: proxmox-credentials
+  namespace: default
+stringData:
+  pm_user: ENC[PLACEHOLDER]
+  pm_password: ENC[PLACEHOLDER]
+sops:
+  encrypted_regex: ^(stringData)$
+  age: []
+  version: 3.7.3

--- a/terraform/00-proxmox-foundation/main.tf
+++ b/terraform/00-proxmox-foundation/main.tf
@@ -1,0 +1,8 @@
+provider "proxmox" {
+  pm_api_url      = var.pm_api_url
+  pm_user         = var.pm_user
+  pm_password     = var.pm_password
+  pm_tls_insecure = true
+}
+
+# TODO: Define Proxmox networks, storage, and templates

--- a/terraform/00-proxmox-foundation/variables.tf
+++ b/terraform/00-proxmox-foundation/variables.tf
@@ -1,0 +1,3 @@
+variable "pm_api_url" { type = string }
+variable "pm_user" { type = string }
+variable "pm_password" { type = string }

--- a/terraform/10-mgmt-talos/main.tf
+++ b/terraform/10-mgmt-talos/main.tf
@@ -1,0 +1,8 @@
+provider "proxmox" {
+  pm_api_url      = var.pm_api_url
+  pm_user         = var.pm_user
+  pm_password     = var.pm_password
+  pm_tls_insecure = true
+}
+
+# TODO: Provision management cluster VMs with proxmox_vm_qemu

--- a/terraform/10-mgmt-talos/variables.tf
+++ b/terraform/10-mgmt-talos/variables.tf
@@ -1,0 +1,3 @@
+variable "pm_api_url" { type = string }
+variable "pm_user" { type = string }
+variable "pm_password" { type = string }

--- a/terraform/10-mgmt-talos/versions.tf
+++ b/terraform/10-mgmt-talos/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers {
+    proxmox = {
+      source  = "Telmate/proxmox"
+      version = "3.0.1-rc5"
+    }
+  }
+}

--- a/terraform/20-capi-operator/main.tf
+++ b/terraform/20-capi-operator/main.tf
@@ -1,0 +1,1 @@
+# TODO: Install Cluster API Operator using Helm

--- a/terraform/20-capi-operator/versions.tf
+++ b/terraform/20-capi-operator/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.12"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.33"
+    }
+  }
+}

--- a/terraform/30-capmox/main.tf
+++ b/terraform/30-capmox/main.tf
@@ -1,0 +1,1 @@
+# TODO: Apply ProxmoxCluster resources and credentials

--- a/terraform/30-capmox/versions.tf
+++ b/terraform/30-capmox/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.33"
+    }
+  }
+}

--- a/terraform/40-clusters/main.tf
+++ b/terraform/40-clusters/main.tf
@@ -1,0 +1,1 @@
+# TODO: Define workload cluster templates and classes

--- a/terraform/40-clusters/versions.tf
+++ b/terraform/40-clusters/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 1.6.0"
+}

--- a/terraform/50-argo/main.tf
+++ b/terraform/50-argo/main.tf
@@ -1,0 +1,1 @@
+# TODO: Deploy Argo CD via Helm using gitops/argocd/values

--- a/terraform/50-argo/versions.tf
+++ b/terraform/50-argo/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.12"
+    }
+  }
+}

--- a/terraform/mgmt-proxmox-talos/terraform.tfvars.example
+++ b/terraform/mgmt-proxmox-talos/terraform.tfvars.example
@@ -1,0 +1,6 @@
+pm_api_url    = "https://proxmox.example:8006/api2/json"
+pm_user       = "root@pam"
+pm_password   = "REPLACEME"
+cluster_name  = "mgmt"
+controlplane_ips = ["10.0.0.2"]
+worker_ips       = []


### PR DESCRIPTION
## Summary
- scaffold placeholder terraform modules for proxmox, capi, and argo
- add sops config and example secret template
- add pre-commit workflow and kubeconform defaults

## Testing
- `SKIP=kubeconform pre-commit run --files .kubeconform.yaml README.md docs/bootstrap.md .github/workflows/pre-commit.yaml .sops.yaml secrets/README.md secrets/proxmox-credentials.sops.example.yaml terraform/00-proxmox-foundation/main.tf terraform/00-proxmox-foundation/variables.tf terraform/10-mgmt-talos/main.tf terraform/10-mgmt-talos/variables.tf terraform/10-mgmt-talos/versions.tf terraform/20-capi-operator/main.tf terraform/20-capi-operator/versions.tf terraform/30-capmox/main.tf terraform/30-capmox/versions.tf terraform/40-clusters/main.tf terraform/40-clusters/versions.tf terraform/50-argo/main.tf terraform/50-argo/versions.tf terraform/mgmt-proxmox-talos/terraform.tfvars.example`
- `kubeconform -summary -strict -ignore-missing-schemas clusters/mgmt/providers/infrastructure-proxmox.yaml clusters/prod/prod-cluster.yaml gitops/argocd/apps/*/application.yaml gitops/argocd/bootstrap/*.yaml`
- `terraform -chdir=terraform/00-proxmox-foundation plan -var pm_api_url=https://proxmox.example -var pm_user=root@pam -var pm_password=example`
- `terraform -chdir=terraform/10-mgmt-talos plan -var pm_api_url=https://proxmox.example -var pm_user=root@pam -var pm_password=example`
- `terraform -chdir=terraform/20-capi-operator plan`
- `terraform -chdir=terraform/30-capmox plan`
- `terraform -chdir=terraform/40-clusters plan`
- `terraform -chdir=terraform/50-argo plan`

------
https://chatgpt.com/codex/tasks/task_e_689b48cd551c832386323ded9525f2f9